### PR TITLE
WIP Implement differentiable trg using einsum and Zygote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 *.jl.cov
 *.jl.mem
 .DS_Store
-/Manifest.toml
 /docs/build/
 /docs/site/

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -113,7 +113,7 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[LinalgBackwards]]
 deps = ["LinearAlgebra", "Random", "Zygote"]
-git-tree-sha1 = "8be94a8a840409dd017234de98330b90f6180699"
+git-tree-sha1 = "fed67af4bbc3cb33f287bc2673366774ba4cf589"
 repo-rev = "master"
 repo-url = "https://github.com/GiggleLiu/LinalgBackwards.jl.git"
 uuid = "8dad3b0d-1a4d-5faa-9471-8c404674cf7c"
@@ -223,10 +223,10 @@ uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
 version = "0.7.2"
 
 [[StaticArrays]]
-deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
-git-tree-sha1 = "3841b39ed5f047db1162627bf5f80a9cd3e39ae2"
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "db23bbf50064c582b6f2b9b043c8e7e98ea8c0c6"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "0.10.3"
+version = "0.11.0"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -115,7 +115,7 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 deps = ["LinearAlgebra", "Random", "Zygote"]
 git-tree-sha1 = "8be94a8a840409dd017234de98330b90f6180699"
 repo-rev = "master"
-repo-url = "git@github.com:GiggleLiu/LinalgBackwards.jl.git"
+repo-url = "https://github.com/GiggleLiu/LinalgBackwards.jl.git"
 uuid = "8dad3b0d-1a4d-5faa-9471-8c404674cf7c"
 version = "0.1.1"
 
@@ -155,7 +155,7 @@ version = "0.3.2"
 deps = ["IRTools", "PkgBenchmark", "TupleTools", "Zygote"]
 git-tree-sha1 = "7689a992f08f32ec5db07067939bccbc7389e846"
 repo-rev = "master"
-repo-url = "git@github.com:under-Peter/OMEinsum.jl.git"
+repo-url = "https://github.com/under-Peter/OMEinsum.jl.git"
 uuid = "ebe7aa44-baf0-506c-a96f-8464559b3922"
 version = "0.1.0"
 

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,276 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[BenchmarkTools]]
+deps = ["JSON", "Printf", "Statistics", "Test"]
+git-tree-sha1 = "5d1dd8577643ba9014574cd40d9c028cd5e4b85a"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "0.4.2"
+
+[[BinDeps]]
+deps = ["Compat", "Libdl", "SHA", "URIParser"]
+git-tree-sha1 = "12093ca6cdd0ee547c39b1870e0c9c3f154d9ca9"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "0.8.10"
+
+[[BinaryProvider]]
+deps = ["Libdl", "SHA"]
+git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"
+uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
+version = "0.5.4"
+
+[[CSTParser]]
+deps = ["LibGit2", "Test", "Tokenize"]
+git-tree-sha1 = "437c93bc191cd55957b3f8dee7794b6131997c56"
+uuid = "00ebfdb7-1f24-5e51-bd34-a7502290713f"
+version = "0.5.2"
+
+[[CommonSubexpressions]]
+deps = ["Test"]
+git-tree-sha1 = "efdaf19ab11c7889334ca247ff4c9f7c322817b0"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.2.0"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "84aa74986c5b9b898b0d1acaf3258741ee64754f"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "2.1.0"
+
+[[Crayons]]
+deps = ["Test"]
+git-tree-sha1 = "f621b8ef51fd2004c7cf157ea47f027fdeac5523"
+uuid = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
+version = "4.0.0"
+
+[[DataStructures]]
+deps = ["InteractiveUtils", "OrderedCollections", "Random", "Serialization", "Test"]
+git-tree-sha1 = "ca971f03e146cf144a9e2f2ce59674f5bf0e8038"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.15.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[DiffResults]]
+deps = ["Compat", "StaticArrays"]
+git-tree-sha1 = "34a4a1e8be7bc99bc9c611b895b5baf37a80584c"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "0.0.4"
+
+[[DiffRules]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "dc0869fb2f5b23466b32ea799bd82c76480167f7"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "0.0.10"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays", "Test"]
+git-tree-sha1 = "9ab8f76758cbabba8d7f103c51dce7f73fcf8e92"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.6.3"
+
+[[ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "InteractiveUtils", "LinearAlgebra", "NaNMath", "Random", "SparseArrays", "SpecialFunctions", "StaticArrays", "Test"]
+git-tree-sha1 = "4c4d727f1b7e0092134fabfab6396b8945c1ea5b"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "0.10.3"
+
+[[IRTools]]
+deps = ["InteractiveUtils", "MacroTools", "Test"]
+git-tree-sha1 = "4d0c6647aa89b3678d03967ca11c8a5cdc83d2b5"
+repo-rev = "master"
+repo-url = "https://github.com/MikeInnes/IRTools.jl.git"
+uuid = "7869d1d1-7146-5819-86e3-90919afe41df"
+version = "0.2.1"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[JSON]]
+deps = ["Dates", "Distributed", "Mmap", "Sockets", "Test", "Unicode"]
+git-tree-sha1 = "1f7a25b53ec67f5e9422f1f551ee216503f4a0fa"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.20.0"
+
+[[LibGit2]]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinalgBackwards]]
+deps = ["LinearAlgebra", "Random", "Zygote"]
+git-tree-sha1 = "8be94a8a840409dd017234de98330b90f6180699"
+repo-rev = "master"
+repo-url = "git@github.com:GiggleLiu/LinalgBackwards.jl.git"
+uuid = "8dad3b0d-1a4d-5faa-9471-8c404674cf7c"
+version = "0.1.1"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MacroTools]]
+deps = ["CSTParser", "Compat", "DataStructures", "Test"]
+git-tree-sha1 = "daecd9e452f38297c686eba90dba2a6d5da52162"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.0"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[NNlib]]
+deps = ["Libdl", "LinearAlgebra", "Requires", "Statistics", "TimerOutputs"]
+git-tree-sha1 = "0c667371391fc6bb31f7f12f96a56a17098b3de8"
+uuid = "872c559c-99b0-510c-b3b7-b6c96a88d5cd"
+version = "0.6.0"
+
+[[NaNMath]]
+deps = ["Compat"]
+git-tree-sha1 = "ce3b85e484a5d4c71dd5316215069311135fa9f2"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.2"
+
+[[OMEinsum]]
+deps = ["IRTools", "PkgBenchmark", "TupleTools", "Zygote"]
+git-tree-sha1 = "7689a992f08f32ec5db07067939bccbc7389e846"
+repo-rev = "master"
+repo-url = "git@github.com:under-Peter/OMEinsum.jl.git"
+uuid = "ebe7aa44-baf0-506c-a96f-8464559b3922"
+version = "0.1.0"
+
+[[OrderedCollections]]
+deps = ["Random", "Serialization", "Test"]
+git-tree-sha1 = "c4c13474d23c60d20a67b217f1d7f22a40edf8f1"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.1.0"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PkgBenchmark]]
+deps = ["BenchmarkTools", "Dates", "InteractiveUtils", "JSON", "LibGit2", "Pkg", "Printf", "ProgressMeter", "Random", "Statistics", "Test"]
+git-tree-sha1 = "cf641fb115ca4c97ce0a20bdddc3ba973724c61e"
+uuid = "32113eaa-f34f-5b0d-bd6c-c81e245fc73d"
+version = "0.2.1"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[ProgressMeter]]
+deps = ["Distributed", "Printf", "Random", "Test"]
+git-tree-sha1 = "48058bc11607676e5bbc0b974af79106c6200787"
+uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
+version = "0.9.0"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Requires]]
+deps = ["Test"]
+git-tree-sha1 = "f6fbf4ba64d295e146e49e021207993b6b48c7d1"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "0.5.2"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SpecialFunctions]]
+deps = ["BinDeps", "BinaryProvider", "Libdl", "Test"]
+git-tree-sha1 = "0b45dc2e45ed77f445617b99ff2adf0f5b0f23ea"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "0.7.2"
+
+[[StaticArrays]]
+deps = ["InteractiveUtils", "LinearAlgebra", "Random", "Statistics", "Test"]
+git-tree-sha1 = "3841b39ed5f047db1162627bf5f80a9cd3e39ae2"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "0.10.3"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[TimerOutputs]]
+deps = ["Crayons", "Printf", "Test", "Unicode"]
+git-tree-sha1 = "b80671c06f8f8bae08c55d67b5ce292c5ae2660c"
+uuid = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
+version = "0.5.0"
+
+[[Tokenize]]
+deps = ["Printf", "Test"]
+git-tree-sha1 = "3e83f60b74911d3042d3550884ca2776386a02b8"
+uuid = "0796e94c-ce3b-5d07-9a54-7f471281c624"
+version = "0.5.3"
+
+[[TupleTools]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "b006524003142128cc6d36189dce337729aa0050"
+uuid = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
+version = "1.1.0"
+
+[[URIParser]]
+deps = ["Test", "Unicode"]
+git-tree-sha1 = "6ddf8244220dfda2f17539fa8c9de20d6c575b69"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.0"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[Zygote]]
+deps = ["DiffRules", "FillArrays", "ForwardDiff", "IRTools", "InteractiveUtils", "LinearAlgebra", "MacroTools", "NNlib", "NaNMath", "Random", "Requires", "SpecialFunctions", "Statistics"]
+git-tree-sha1 = "4b9c0799b296c73b60397ed167b6455c31820d06"
+repo-rev = "master"
+repo-url = "https://github.com/FluxML/Zygote.jl.git"
+uuid = "e88e6eb3-aa80-5325-afca-941959d7151f"
+version = "0.3.1"

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,13 @@ uuid = "6b36f460-1d4e-5459-a8c4-3ab8f40f7d47"
 authors = ["Andreas Peter <andreas.peter.ch@gmail.com>"]
 version = "0.1.0"
 
+[deps]
+IRTools = "7869d1d1-7146-5819-86e3-90919afe41df"
+LinalgBackwards = "8dad3b0d-1a4d-5faa-9471-8c404674cf7c"
+OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
+TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/TensorNetworkAD.jl
+++ b/src/TensorNetworkAD.jl
@@ -1,10 +1,11 @@
 module TensorNetworkAD
+using Zygote, LinalgBackwards
+using OMEinsum
 
-@doc raw"
-    greet()
-greet the world!
-"
+export trg, num_grad
 
-greet() = print("Hello World!")
+include("einsum.jl")
+include("trg.jl")
+include("autodiff.jl")
 
 end # module

--- a/src/autodiff.jl
+++ b/src/autodiff.jl
@@ -1,0 +1,20 @@
+using Zygote
+
+@Zygote.nograd contractionindices
+
+@doc raw"
+    num_grad(f, K::Real; [δ = 1e-5])
+return the numerical gradient of `f` at `K` calculated with
+`(f(K+δ/2) - f(K-δ/2))/δ`
+"
+num_grad(f, K::Real; δ::Real = 1e-5) = (f(K+δ/2) - f(K-δ/2))/δ
+
+@doc raw"
+    num_grad(f, K::AbstractArray; [δ = 1e-5])
+return the numerical gradient of `f` for each element of `K`.
+"
+function num_grad(f, a::AbstractArray; δ::Real = 1e-5)
+    map(CartesianIndices(a)) do i
+        num_grad(a[i], x -> (ac = copy(a); ac[i] = x; f(ac)), δ)
+    end
+end

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -1,0 +1,39 @@
+using OMEinsum
+using TupleTools
+@doc raw"
+    contractionindices(ixs, iy)
+calculate the indices of the intermediate tensor
+resulting from contracting the first two indices of
+`ixs`.
+returns both the indices of the contraction and the intermediate
+result indices.
+
+# Example
+
+Product of three matrices
+```julia
+julia> contractionindices(((1,2),(2,3),(3,4)), (1,4))
+(((1, 2), (2, 3)), (1, 3))
+```
+"
+function contractionindices(ixs::NTuple{N, T where T}, iy) where N
+    N <= 2 && return (ixs, iy)
+    ix12 = unique(vcat(collect(ixs[1]), collect(ixs[2])))
+    allothers = vcat(map(collect,ixs[3:end])..., collect(iy))
+    ((ixs[1], ixs[2]), Tuple(i for i in ix12 if i in allothers))
+end
+
+@doc raw"
+    meinsum(ixs, xs, iy)
+like `einsum(ixs,xs,iy)` but contracting pairwise from
+left to right.
+"
+function meinsum(ixs, xs, iy)
+    ixstmp, iytmp = contractionindices(ixs, iy)
+    xstmp = Tuple(xs[i] for i in 1:length(ixstmp))
+    x = einsum(ixstmp, xstmp, iytmp)
+    length(xs) <= 2 && return x
+    nixs = (iytmp, map(i -> ixs[i], (3:length(ixs)...,))...)
+    nxs = (x, map(i -> xs[i], (3:length(ixs)...,))...)
+    return meinsum(nixs, nxs, iy)
+end

--- a/src/trg.jl
+++ b/src/trg.jl
@@ -1,0 +1,40 @@
+# using OMEinsum
+using LinalgBackwards
+
+function trg(k, χ, niter)
+    D = 2
+    inds = 1:D
+    M = [sqrt(cosh(k)) sqrt(sinh(k)) ; sqrt(cosh(k)) -sqrt(sinh(k))]
+    T = meinsum(((-1,1),(-1,2),(-1,3),(-1,4)), (M,M,M,M), (1,2,3,4))
+
+    lnZ = zero(k)
+    for n in 1:niter
+        maxval = maximum(T)
+        T /= maxval
+        lnZ += 2^(niter-n+1)*log(maxval)
+
+        d2 = size(T,1)^2
+        Ma = reshape(meinsum(((1,2,3,4),), (T,),(3,2,1,4)), d2, d2)
+        Mb = reshape(meinsum(((1,2,3,4),), (T,),(4,3,2,1)), d2, d2)
+        s1, s3 = trg_svd(Ma, χ)
+        s2, s4 = trg_svd(Mb, χ)
+
+        T = meinsum(((-1,-2,1), (-2,-3,2), (3,-3,-4), (4,-4,-1)), (s1,s2,s3,s4),(1,2,3,4))
+    end
+    trace = meinsum(((1,2,1,2),), (T,), ())[1]
+    lnZ += log(trace)
+    return lnZ
+end
+
+
+function trg_svd(Ma, Dmax; tol::Float64=1e-12)
+    U, S, V = svd(Ma)
+    Dmax = min(searchsortedfirst(S, tol, rev=true), Dmax)
+    D = isqrt(size(Ma, 1))
+    FS = S[1:Dmax]
+    sqrtFSp = sqrt.(FS)
+    S1 = reshape(meinsum(((1,2),(2,)), (U[:,1:Dmax],  sqrtFSp), (1,2)), (D, D, Dmax))
+    S3 = reshape(meinsum(((1,2),(1,)), (copy(V')[1:Dmax,:], sqrtFSp), (1,2)), (Dmax, D, D))
+
+    S1, S3
+end

--- a/test/ctmrg.jl
+++ b/test/ctmrg.jl
@@ -1,0 +1,11 @@
+using TensorNetworkAD
+using Test, Random
+using Zygote
+
+@testset "ctmrg" begin
+    Random.seed!(2)
+    χ = 5
+    niter = 5
+    # $ python 2_variational_iPEPS/variational.py -model TFIM -D 3 -chi 10 -Niter 10 -Nepochs 10
+    @test_broken isapprox(ctmrg(:TFIM; nepochs=10, χ=10, D=3, niter=10).E, -2.1256619, atol=1e-5)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,4 +3,5 @@ using Test
 
 @testset "TensorNetworkAD.jl" begin
     include("trg.jl")
+    include("ctmrg.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,5 +2,5 @@ using TensorNetworkAD
 using Test
 
 @testset "TensorNetworkAD.jl" begin
-    # Write your own tests here.
+    include("trg.jl")
 end

--- a/test/trg.jl
+++ b/test/trg.jl
@@ -1,0 +1,5 @@
+using Zygote
+@testset "trg" begin
+    foo = x -> trg(x,5,5)
+    @test num_grad(foo, 0.4, δ=1e-6) ≈ Zygote.gradient(foo, 0.4)[1]
+end

--- a/test/trg.jl
+++ b/test/trg.jl
@@ -1,5 +1,19 @@
+using TensorNetworkAD
+using Test
 using Zygote
+
 @testset "trg" begin
-    foo = x -> trg(x,5,5)
+    χ = 5
+    niter = 5
+    foo = x -> trg(x, χ, niter)
+    @test foo(0.4)/2^niter ≈ 0.8919788686747141  # the pytorch result
+    @test num_grad(foo, 0.4, δ=1e-6) ≈ Zygote.gradient(foo, 0.4)[1]
+end
+
+@testset "trg" begin
+    χ = 5
+    niter = 5
+    foo = x -> trg(x, χ, niter)
+    @test foo(0.4)/2^niter ≈ 0.8919788686747141  # the pytorch result
     @test num_grad(foo, 0.4, δ=1e-6) ≈ Zygote.gradient(foo, 0.4)[1]
 end

--- a/test/trg.jl
+++ b/test/trg.jl
@@ -6,14 +6,10 @@ using Zygote
     χ = 5
     niter = 5
     foo = x -> trg(x, χ, niter)
-    @test foo(0.4)/2^niter ≈ 0.8919788686747141  # the pytorch result
-    @test num_grad(foo, 0.4, δ=1e-6) ≈ Zygote.gradient(foo, 0.4)[1]
-end
-
-@testset "trg" begin
-    χ = 5
-    niter = 5
-    foo = x -> trg(x, χ, niter)
-    @test foo(0.4)/2^niter ≈ 0.8919788686747141  # the pytorch result
+    # the pytorch result with tensorgrad
+    # https://github.com/wangleiphy/tensorgrad
+    # clone this repo and type
+    # $ python 1_ising_TRG/ising.py -chi 5 -Niter 5
+    @test foo(0.4)/2^niter ≈ 0.8919788686747141
     @test num_grad(foo, 0.4, δ=1e-6) ≈ Zygote.gradient(foo, 0.4)[1]
 end


### PR DESCRIPTION
First implementation of differentiable trg with einsum and Zygote. 

Because I did not want to write the pairwise contractions myself, I created a function `meinsum` that has the same arguments as einsum but evaluates any contraction left-to-right. This should probably be a keyword in `einsum` (order = :leftright or order = :full) or something like that.

Works with Zygote and IRTools master branches.

As far as performance goes, for `k=10` and `niter = 10`, I have

- forward: 330 ms
- num_grad: 670 ms
- Zygote: 980 ms

But as array sizes grow, the memory overhead of Zygote might incur a larger penalty.